### PR TITLE
Allow colon in backend names in overrides

### DIFF
--- a/check_haproxy
+++ b/check_haproxy
@@ -437,7 +437,7 @@ sub build_checks {
       $override
     );
 
-    next unless ($override =~ /([^:]+):([udx]?)(?:,([0-9]*)(?:,([0-9]*)(?:,([0-9]*)%?(?:,([0-9]*)%?)?)?)?)?/);
+    next unless ($override =~ /([a-zA-Z0-9-_:.]+):([udx]?)(?:,([0-9]*)(?:,([0-9]*)(?:,([0-9]*)%?(?:,([0-9]*)%?)?)?)?)?/);
 
     next unless exists $data{$1};
 


### PR DESCRIPTION
Citing official documenationt at
https://docs.haproxy.org/2.6/configuration.html#4

> All proxy names must be formed from upper and lower case letters, digits,
> '-' (dash), '_' (underscore) , '.' (dot) and ':' (colon). ACL names are
> case-sensitive, which means that "www" and "WWW" are two different proxies.

I didn't do extensive testing, we have only couple cases where we are using overrides. So please approach this as simple "works for us" and better double check.